### PR TITLE
Ltm 38 - 회차 선택 Picker View 기능 구현 및 당첨 정보 연동 완료

### DIFF
--- a/LottoMate/LottoMate.xcodeproj/project.pbxproj
+++ b/LottoMate/LottoMate.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		096552622C7F161000897DA7 /* PensionLotteryResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096552612C7F161000897DA7 /* PensionLotteryResultModel.swift */; };
 		096552682C809C5B00897DA7 /* GoogleLoginTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096552672C809C5B00897DA7 /* GoogleLoginTestView.swift */; };
 		096552A92C8883D100897DA7 /* CustomSquareButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096552A82C8883D100897DA7 /* CustomSquareButton.swift */; };
+		096552AB2C8AE0C200897DA7 /* DrawRoundBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096552AA2C8AE0C200897DA7 /* DrawRoundBottomSheet.swift */; };
+		096552AF2C8B01C500897DA7 /* DrawRoundBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096552AE2C8B01C500897DA7 /* DrawRoundBottomSheetViewController.swift */; };
 		0969665C2C4FE27600BCE28B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0969665B2C4FE27600BCE28B /* AppDelegate.swift */; };
 		0969665E2C4FE27600BCE28B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0969665D2C4FE27600BCE28B /* SceneDelegate.swift */; };
 		096966632C4FE27600BCE28B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 096966612C4FE27600BCE28B /* Main.storyboard */; };
@@ -116,6 +118,8 @@
 		096552672C809C5B00897DA7 /* GoogleLoginTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleLoginTestView.swift; sourceTree = "<group>"; };
 		0965526C2C837F3200897DA7 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		096552A82C8883D100897DA7 /* CustomSquareButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSquareButton.swift; sourceTree = "<group>"; };
+		096552AA2C8AE0C200897DA7 /* DrawRoundBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawRoundBottomSheet.swift; sourceTree = "<group>"; };
+		096552AE2C8B01C500897DA7 /* DrawRoundBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawRoundBottomSheetViewController.swift; sourceTree = "<group>"; };
 		096966582C4FE27600BCE28B /* LottoMate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LottoMate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0969665B2C4FE27600BCE28B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0969665D2C4FE27600BCE28B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -246,6 +250,8 @@
 				09554D1C2C649740009D1847 /* PrizeInfoCardView.swift */,
 				09554D212C64B798009D1847 /* LotteryTypeButtonsView.swift */,
 				091672CA2C7E0EE800959767 /* BannerView.swift */,
+				096552AA2C8AE0C200897DA7 /* DrawRoundBottomSheet.swift */,
+				096552AE2C8B01C500897DA7 /* DrawRoundBottomSheetViewController.swift */,
 			);
 			path = Subviews;
 			sourceTree = "<group>";
@@ -637,6 +643,7 @@
 				096552A92C8883D100897DA7 /* CustomSquareButton.swift in Sources */,
 				09341CA12C58D8C500B47642 /* WinningInfoDetailView.swift in Sources */,
 				091672BE2C78CC6300959767 /* LottoWinningInfoView.swift in Sources */,
+				096552AF2C8B01C500897DA7 /* DrawRoundBottomSheetViewController.swift in Sources */,
 				0969665C2C4FE27600BCE28B /* AppDelegate.swift in Sources */,
 				09554D222C64B798009D1847 /* LotteryTypeButtonsView.swift in Sources */,
 				09554D422C6908E4009D1847 /* LottoMateViewModel.swift in Sources */,
@@ -647,6 +654,7 @@
 				091672C32C7CCB2600959767 /* PensionLotteryWinningInfoView.swift in Sources */,
 				09554D1D2C649740009D1847 /* PrizeInfoCardView.swift in Sources */,
 				096552682C809C5B00897DA7 /* GoogleLoginTestView.swift in Sources */,
+				096552AB2C8AE0C200897DA7 /* DrawRoundBottomSheet.swift in Sources */,
 				0969665E2C4FE27600BCE28B /* SceneDelegate.swift in Sources */,
 				09554D132C5E5FB6009D1847 /* SampleData.swift in Sources */,
 				09341C262C53A71000B47642 /* TabBarViewController.swift in Sources */,

--- a/LottoMate/LottoMate.xcworkspace/xcuserdata/mirae.xcuserdatad/IDEFindNavigatorScopes.plist
+++ b/LottoMate/LottoMate.xcworkspace/xcuserdata/mirae.xcuserdatad/IDEFindNavigatorScopes.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/LottoMate/LottoMate/Models/LottoMateViewModel.swift
+++ b/LottoMate/LottoMate/Models/LottoMateViewModel.swift
@@ -22,18 +22,21 @@ class LottoMateViewModel {
     
     var selectedLotteryType = BehaviorSubject<LotteryType>(value: .lotto)
     var selectedSpeetoType = BehaviorSubject<Int>(value: 0)
-    
+    /// 로또 회차 & 날짜 정보
     var lottoDrawRoundData = BehaviorSubject<[(Int, String)]?>(value: nil)
+    /// 연금복권 회차 & 날짜 정보
+    var pensionLotteryDrawRoundData = BehaviorSubject<[(Int, String)]?>(value: nil)
     
     private let apiClient = LottoMateClient()
     private let disposeBag = DisposeBag()
     
     private init() { }
     
-    let lottoRoundTapEvent = BehaviorRelay<Bool?>(value: false)
+    /// 로또, 연금복권 당첨 정보 상세에서 회차를 탭하면 픽커뷰가 표시됩니다.
+    let drawRoundTapEvent = BehaviorRelay<Bool?>(value: false)
     let speetoTypeTapEvent = BehaviorRelay<SpeetoType?>(value: .the2000)
     
-    /// 최신 회차 복권 당첨 정보 가져오기
+    /// 최신 회차 복권 당첨 정보를 가져오는 메서드
     func fetchLottoHome() {
         apiClient.getLottoHome()
             .subscribe(onNext: { [weak self] result in
@@ -74,8 +77,8 @@ class LottoMateViewModel {
             })
             .disposed(by: disposeBag)
     }
-    /// 회차 선택 픽커 뷰 데이터
-    func drawRoundPickerViewData() {
+    /// 로또 회차 선택 픽커 뷰 데이터
+    func lottoDrawRoundPickerViewData() {
         guard let latestLottoRound = latestLotteryResult.value?.the645.drwNum,
               let latestLottoDrawDate = latestLotteryResult.value?.the645.drwDate else { return }
         
@@ -86,7 +89,7 @@ class LottoMateViewModel {
                 currentData = data
             }
         } catch {
-            print("Error getting current value: \(error)")
+            print("Error getting current lotto value: \(error)")
         }
         
         let dateFormatter = DateFormatter()
@@ -107,9 +110,37 @@ class LottoMateViewModel {
         // 옵셔널 값으로 새 데이터를 전송합니다.
         lottoDrawRoundData.onNext(currentData)
     }
-
-    /// 마지막 아이템에 도달하면 호출되어 추가 데이터를 로드하는 메서드
-    func loadMoreDrawRounds() {
+    /// 연금복권 회차 선택 픽커 뷰 데이터
+    func pensionLotteryDrawRoundPickerViewData() {
+        guard let latestPensionLotteryRound = latestLotteryResult.value?.the720.drwNum,
+              let latestPensionLotteryDrawDate = latestLotteryResult.value?.the720.drwDate else { return }
+        
+        var currentData: [(Int, String)] = []
+        do {
+            if let data = try pensionLotteryDrawRoundData.value() {
+                currentData = data
+            }
+        } catch {
+            print("Error getting current pension lottery value: \(error)")
+        }
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        // String 타입의 날짜 정보를 Date 타입으로 변경
+        if let drawDate = dateFormatter.date(from: latestPensionLotteryDrawDate) {
+            let previousDrawDates = calculatePreviousDrawDates(from: latestPensionLotteryRound, date: drawDate, numberOfRounds: 100)
+            
+            for (round, date) in previousDrawDates.sorted(by: { $0.key > $1.key }) {
+                let formattedDate = dateFormatter.string(from: date)
+                let newRoundData: (Int, String) = (round, formattedDate)
+                currentData.append(newRoundData)
+            }
+        }
+        pensionLotteryDrawRoundData.onNext(currentData)
+    }
+    /// 마지막 아이템에 도달하면 호출되어 추가 로또 회차 데이터를 로드하는 메서드
+    func loadMoreLottoDrawRounds() {
         do {
             // 현재 lottoDrawRoundData의 값을 가져옵니다.
             var currentData: [(Int, String)] = []
@@ -149,10 +180,47 @@ class LottoMateViewModel {
                 }
             }
         } catch {
-            print("Error fetching data: \(error)")
+            print("Error loading more lotto draw rounds data: \(error)")
         }
     }
-    
+    /// 마지막 아이템에 도달하면 호출되어 추가 연금복권 회차 데이터를 로드하는 메서드
+    func loadMorePensionLotteryDrawRounds() {
+        do {
+            var currentData: [(Int, String)] = []
+            if let data = try pensionLotteryDrawRoundData.value() {
+                currentData = data
+            }
+            if let lastRound = currentData.last?.0, lastRound > 1 {
+                let updatedLastRound = lastRound - 1
+                let startRound = max(updatedLastRound - 100, 1)
+                print("start round: \(startRound)")
+                let newRounds = (startRound...updatedLastRound).reversed()
+                
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                
+                if let lastDrawDateString = currentData.last?.1,
+                   var lastDrawDate = dateFormatter.date(from: lastDrawDateString) {
+                    
+                    lastDrawDate = Calendar.current.date(byAdding: .day, value: -7, to: lastDrawDate) ?? lastDrawDate
+                    
+                    let previousDrawDates = calculatePreviousDrawDates(from: updatedLastRound, date: lastDrawDate, numberOfRounds: 100)
+                    
+                    for round in newRounds {
+                        if let date = previousDrawDates[round] {
+                            let formattedDate = dateFormatter.string(from: date)
+                            let newRoundData: (Int, String) = (round, formattedDate)
+                            currentData.append(newRoundData)
+                        }
+                    }
+                    print("currentData: \(currentData)")
+                    pensionLotteryDrawRoundData.onNext(currentData)
+                }
+            }
+        } catch {
+            print("Error loading more pension lottery draw rounds data: \(error)")
+        }
+    }
     // 특정 회차와 해당 회차 날짜로부터 이전 회차들의 날짜를 계산하는 함수
     func calculatePreviousDrawDates(from drawRound: Int, date: Date, numberOfRounds: Int) -> [Int: Date] {
         var drawDates: [Int: Date] = [:]
@@ -169,7 +237,6 @@ class LottoMateViewModel {
                 currentRound -= 1
             }
         }
-        
         return drawDates
     }
 }

--- a/LottoMate/LottoMate/Models/LottoMateViewModel.swift
+++ b/LottoMate/LottoMate/Models/LottoMateViewModel.swift
@@ -23,6 +23,8 @@ class LottoMateViewModel {
     var selectedLotteryType = BehaviorSubject<LotteryType>(value: .lotto)
     var selectedSpeetoType = BehaviorSubject<Int>(value: 0)
     
+    var lottoDrawRoundData = BehaviorSubject<[(Int, String)]?>(value: nil)
+    
     private let apiClient = LottoMateClient()
     private let disposeBag = DisposeBag()
     
@@ -64,12 +66,110 @@ class LottoMateViewModel {
     }
     /// 회차별 연금복권 정보 가져오기
     func fetchPensionLotteryResult(round: Int) {
-    apiClient.getPensionLotteryResult(round: round)
-        .subscribe(onNext: { [weak self] result in
-            self?.pensionLotteryResult.accept(result)
-        }, onError: { error in
-            print("Error fetching pension lottery result: \(error)")
-        })
-        .disposed(by: disposeBag)
-}
+        apiClient.getPensionLotteryResult(round: round)
+            .subscribe(onNext: { [weak self] result in
+                self?.pensionLotteryResult.accept(result)
+            }, onError: { error in
+                print("Error fetching pension lottery result: \(error)")
+            })
+            .disposed(by: disposeBag)
+    }
+    /// 회차 선택 픽커 뷰 데이터
+    func drawRoundPickerViewData() {
+        guard let latestLottoRound = latestLotteryResult.value?.the645.drwNum,
+              let latestLottoDrawDate = latestLotteryResult.value?.the645.drwDate else { return }
+        
+        // 현재 값을 가져옵니다.
+        var currentData: [(Int, String)] = []
+        do {
+            if let data = try lottoDrawRoundData.value() {
+                currentData = data
+            }
+        } catch {
+            print("Error getting current value: \(error)")
+        }
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        // 최신 회차 날짜로부터 100회 전까지의 회차와 날짜 계산
+        if let drawDate = dateFormatter.date(from: latestLottoDrawDate) {
+            let previousDrawDates = calculatePreviousDrawDates(from: latestLottoRound, date: drawDate, numberOfRounds: 100)
+            
+            // 계산된 회차와 날짜를 currentData에 추가
+            for (round, date) in previousDrawDates.sorted(by: { $0.key > $1.key }) {
+                let formattedDate = dateFormatter.string(from: date)
+                let newRoundData: (Int, String) = (round, formattedDate)
+                currentData.append(newRoundData)
+            }
+        }
+        
+        // 옵셔널 값으로 새 데이터를 전송합니다.
+        lottoDrawRoundData.onNext(currentData)
+    }
+
+    /// 마지막 아이템에 도달하면 호출되어 추가 데이터를 로드하는 메서드
+    func loadMoreDrawRounds() {
+        do {
+            // 현재 lottoDrawRoundData의 값을 가져옵니다.
+            var currentData: [(Int, String)] = []
+            if let data = try lottoDrawRoundData.value() {
+                currentData = data
+            }
+
+            // 마지막 튜플에서 마지막 회차 값을 가져옵니다.
+            if let lastRound = currentData.last?.0, lastRound > 1 {
+                let updatedLastRound = lastRound - 1
+                let startRound = max(updatedLastRound - 100, 1)
+                let newRounds = (startRound..<updatedLastRound).reversed()
+                
+                // 마지막 회차의 날짜 가져오기
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                
+                // 마지막 회차의 날짜를 추출하고 7일 전으로 업데이트
+                if let lastDrawDateString = currentData.last?.1,
+                   var lastDrawDate = dateFormatter.date(from: lastDrawDateString) {
+                    
+                    // 날짜를 7일 전으로 이동
+                    lastDrawDate = Calendar.current.date(byAdding: .day, value: -7, to: lastDrawDate) ?? lastDrawDate
+                    
+                    // 새로운 회차의 날짜를 계산
+                    let previousDrawDates = calculatePreviousDrawDates(from: updatedLastRound, date: lastDrawDate, numberOfRounds: 100)
+                    
+                    // 새 회차 데이터를 튜플로 생성하여 배열에 추가
+                    for (round, date) in previousDrawDates.sorted(by: { $0.key > $1.key }) {
+                        let formattedDate = dateFormatter.string(from: date)
+                        let newRoundData: (Int, String) = (round, formattedDate)
+                        currentData.append(newRoundData)
+                    }
+
+                    // 새 데이터를 전송합니다.
+                    lottoDrawRoundData.onNext(currentData)
+                }
+            }
+        } catch {
+            print("Error fetching data: \(error)")
+        }
+    }
+    
+    // 특정 회차와 해당 회차 날짜로부터 이전 회차들의 날짜를 계산하는 함수
+    func calculatePreviousDrawDates(from drawRound: Int, date: Date, numberOfRounds: Int) -> [Int: Date] {
+        var drawDates: [Int: Date] = [:]
+        var currentRound = drawRound
+        var currentDate = date
+        
+        // 일주일씩 날짜를 빼면서 이전 회차들의 날짜를 계산
+        for _ in 0..<numberOfRounds {
+            drawDates[currentRound] = currentDate
+            
+            // 1주일(7일) 전으로 날짜를 이동
+            if let newDate = Calendar.current.date(byAdding: .day, value: -7, to: currentDate) {
+                currentDate = newDate
+                currentRound -= 1
+            }
+        }
+        
+        return drawDates
+    }
 }

--- a/LottoMate/LottoMate/Views/TabViews/TestButtonView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/TestButtonView.swift
@@ -20,14 +20,15 @@ class TestButtonView: UIView {
     public let defaultSolidButton = StyledButton(title: "Test Button", buttonStyle: .solid(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 0, horizontalPadding: 0)
     
     let textView = UITextView()
+    let drawRoundTestView = DrawRoundBottomSheet()
     
     init() {
         super.init(frame: .zero)
         backgroundColor = .white
         
 //        #if !NO_SERVER
-//        viewModel.fetchLottoHome()
-//        bindData()
+        viewModel.fetchLottoHome()
+        bindData()
 //        #endif
                 
         defaultSolidButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
@@ -36,10 +37,10 @@ class TestButtonView: UIView {
         
         addSubview(rootFlexContainer)
         
-        rootFlexContainer.flex.direction(.column).alignItems(.center).paddingHorizontal(10).define { flex in
+        rootFlexContainer.flex.direction(.column).define { flex in
             flex.addItem(defaultSolidButton).width(127).height(48).marginBottom(48)
-            flex.addItem(textView).grow(1)
-        }
+//            flex.addItem(drawRoundTestView).grow(1)
+        }.border(1, .red)
     }
     
     required init?(coder: NSCoder) {
@@ -48,7 +49,7 @@ class TestButtonView: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        rootFlexContainer.pin.top().horizontally().margin(pin.safeArea)
+        rootFlexContainer.pin.top(pin.safeArea.top).horizontally()
         rootFlexContainer.flex.layout(mode: .adjustHeight)
     }
     

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/LottoWinningInfoView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/LottoWinningInfoView.swift
@@ -10,6 +10,7 @@ import PinLayout
 import FlexLayout
 import RxSwift
 import RxCocoa
+import BottomSheet
 
 class LottoWinningInfoView: UIView {
     let viewModel = LottoMateViewModel.shared

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/WinningInfoDetailView+DrawView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/WinningInfoDetailView+DrawView.swift
@@ -16,8 +16,6 @@ extension LottoWinningInfoView {
         styleLabel(for: lotteryDrawRound, fontStyle: .headline1, textColor: .primaryGray)
         styleLabel(for: drawDate, fontStyle: .label2, textColor: .gray_ACACAC)
         
-//        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapDrawView))
-//        lotteryDrawingInfo.addGestureRecognizer(tapGesture)
         lotteryDrawingInfo.isUserInteractionEnabled = true
         
         let previousRoundBtnImage = UIImage(named: "small_arrow_left")

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/WinningInfoDetailView+DrawView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/LottoWinningInfoDetail/WinningInfoDetailView+DrawView.swift
@@ -43,7 +43,7 @@ extension LottoWinningInfoView {
             .when(.recognized)
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
-                self.viewModel.lottoRoundTapEvent.accept(true)
+                self.viewModel.drawRoundTapEvent.accept(true)
             })
             .disposed(by: disposeBag)
     }

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/PensionLotteryWinningInfoDetail/PensionLotteryWinningInfoView+UIConfiguration.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/PensionLotteryWinningInfoDetail/PensionLotteryWinningInfoView+UIConfiguration.swift
@@ -13,8 +13,6 @@ extension PensionLotteryWinningInfoView {
         styleLabel(for: lotteryDrawRound, fontStyle: .headline1, textColor: .primaryGray)
         styleLabel(for: drawDate, fontStyle: .label2, textColor: .gray_ACACAC)
         
-        //        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapDrawView))
-        //        lotteryDrawingInfo.addGestureRecognizer(tapGesture)
         lotteryDrawingInfo.isUserInteractionEnabled = true
         
         let previousRoundBtnImage = UIImage(named: "small_arrow_left")

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/PensionLotteryWinningInfoDetail/PensionLotteryWinningInfoView+UIConfiguration.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/PensionLotteryWinningInfoDetail/PensionLotteryWinningInfoView+UIConfiguration.swift
@@ -35,5 +35,13 @@ extension PensionLotteryWinningInfoView {
                 }
             })
             .disposed(by: disposeBag)
+        
+        lotteryDrawingInfo.rx.tapGesture()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                self.viewModel.drawRoundTapEvent.accept(true)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawPickerViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawPickerViewController.swift
@@ -8,9 +8,13 @@
 import UIKit
 import PinLayout
 import FlexLayout
+import RxSwift
+import RxGesture
 
 class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSource {
+    private let viewModel = LottoMateViewModel.shared
     fileprivate let rootFlexContainer = UIView()
+    private let disposeBag = DisposeBag()
     
     private let pickerView = UIPickerView()
     private let data = SampleDrawInfo.sampleData
@@ -18,10 +22,23 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
     public let cancelButton = StyledButton(title: "취소", buttonStyle: .assistive(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
     public let confirmButton = StyledButton(title: "확인", buttonStyle: .solid(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
     
-    var selectedDrawInfo: ((SampleDrawInfo) -> Void)?
+    var selectedDrawRound: ((Int) -> Void)?
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 원하는 row (예: 3번째 row)를 선택 상태로 설정
+        if let currentRound = viewModel.currentLottoRound.value, let data = try? viewModel.lottoDrawRoundData.value() {
+            if let selectedRow = rowForDraw(round: currentRound, from: data) {
+                pickerView.selectRow(selectedRow, inComponent: 0, animated: true)
+            }
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        cancelButtonAction()
         
         pickerView.delegate = self
         pickerView.dataSource = self
@@ -34,12 +51,19 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
         pickerTitleLabel.text = "회차 선택"
         styleLabel(for: pickerTitleLabel, fontStyle: .headline1, textColor: .black)
         
+        // 데이터가 업데이트될 때마다 pickerView를 리로드
+        viewModel.lottoDrawRoundData
+            .subscribe(onNext: { [weak self] _ in
+                self?.pickerView.reloadAllComponents() // 데이터 변경 시 UIPickerView 리로드
+            })
+            .disposed(by: disposeBag)
+        
         view.addSubview(rootFlexContainer)
         
         rootFlexContainer.flex.direction(.column).paddingTop(32).paddingBottom(28).define { flex in
-            flex.addItem(pickerTitleLabel).alignSelf(.start).paddingHorizontal(20).marginBottom(14)
+            flex.addItem(pickerTitleLabel).alignSelf(.start).paddingHorizontal(20).marginBottom(24)
             flex.addItem(pickerView).height(120)
-            flex.addItem().direction(.row).justifyContent(.spaceBetween).gap(15).paddingHorizontal(20).marginTop(14).define { flex in
+            flex.addItem().direction(.row).justifyContent(.spaceBetween).gap(15).paddingHorizontal(20).marginTop(24).define { flex in
                 flex.addItem(cancelButton).grow(1)
                 flex.addItem(confirmButton).grow(1)
             }
@@ -52,22 +76,58 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
         rootFlexContainer.flex.layout(mode: .adjustHeight)
     }
     
+    func cancelButtonAction() {
+        cancelButton.rx.tapGesture()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                // 현재 ViewController를 dismiss
+                self?.dismiss(animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func confirmButtonAction() {
+        
+    }
+    
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
     
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return data.count
+        do {
+            if let data = try viewModel.lottoDrawRoundData.value() {
+                return data.count
+            } else {
+                return 0
+            }
+        } catch {
+            print("Error fetching data: \(error)")
+            return 0
+        }
     }
     
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        let drawInfo = data[row]
-        return "\(drawInfo.drawNumber)회 \(drawInfo.drawDate)"
-    }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        let selectedInfo = data[row]
-        selectedDrawInfo?(selectedInfo)
+        let data = try? viewModel.lottoDrawRoundData.value()
+        guard let data else { return }
+        
+        confirmButton.rx.tapGesture()
+            .when(.recognized)
+            .subscribe(onNext: { [weak self] _ in
+                guard let self = self else { return }
+                // 현재 ViewController를 dismiss
+                let selectedRound = data[row].0
+                self.viewModel.fetchLottoResult(round: selectedRound)
+                self.viewModel.currentLottoRound.accept(selectedRound)
+                self.dismiss(animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
+        
+        // 마지막 아이템 도달 시 회차를 추가로 가져옴
+        if row == data.count - 1 {
+            viewModel.loadMoreDrawRounds()
+        }
     }
     
     func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
@@ -75,17 +135,53 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
     }
     
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let pickerLabel = UILabel()
-        let drawInfo = data[row]
-        var pickerLabelText = "\(drawInfo.drawNumber)회 \(drawInfo.drawDate)"
-        pickerLabel.text = pickerLabelText
-        pickerLabel.font = Typography.font(.headline1)()
-        pickerLabel.textAlignment = NSTextAlignment.center
+        /// 회차 & 날짜 컨테이너
+        let containerView = UIView()
+        
+        let drawRoundLabel = UILabel()
+        let drawDateLabel = UILabel()
+        
+        let data = try? viewModel.lottoDrawRoundData.value()
+        if let drawInfo = data?[row] {
+            let roundText = "\(drawInfo.0)회"
+            drawRoundLabel.text = roundText
+            drawRoundLabel.font = Typography.font(.headline1)()
+//            drawRoundLabel.textColor = .black
+            drawRoundLabel.textAlignment = NSTextAlignment.right
+            
+            let dateText = drawInfo.1.reformatDate
+            drawDateLabel.text = dateText
+            drawDateLabel.font = Typography.font(.body1)()
+//            drawDateLabel.textColor = .black
+            drawDateLabel.textAlignment = NSTextAlignment.left
+            
+            // 여러 기기에서 확인 필요
+            drawRoundLabel.frame = CGRect(x: -20, y: 0, width: pickerView.bounds.width / 2, height: pickerView.rowSize(forComponent: component).height)
+            drawDateLabel.frame = CGRect(x: pickerView.bounds.width / 2, y: 0, width: pickerView.bounds.width / 2, height: pickerView.rowSize(forComponent: component).height)
+            
+            // 라벨을 컨테이너에 추가
+            containerView.addSubview(drawRoundLabel)
+            containerView.addSubview(drawDateLabel)
+        }
+        
+        containerView.backgroundColor = .red5
+        containerView.frame = CGRect(x: 0, y: 0, width: pickerView.bounds.width, height: 40)
         
         pickerView.subviews.forEach {
             $0.backgroundColor = .clear
         }
         
-        return pickerLabel
+        return containerView
+    }
+    
+    func rowForDraw(round: Int, from data: [(Int, String)]) -> Int? {
+        // data 배열에서 주어진 회차(round) 값에 해당하는 row를 찾음
+        for (index, drawInfo) in data.enumerated() {
+            if drawInfo.0 == round {
+                return index
+            }
+        }
+        // 만약 해당하는 회차가 없다면 nil을 반환
+        return nil
     }
 }

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawPickerViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawPickerViewController.swift
@@ -17,17 +17,13 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
     private let disposeBag = DisposeBag()
     
     private let pickerView = UIPickerView()
-    private let data = SampleDrawInfo.sampleData
     private let pickerTitleLabel = UILabel()
-    public let cancelButton = StyledButton(title: "취소", buttonStyle: .assistive(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
-    public let confirmButton = StyledButton(title: "확인", buttonStyle: .solid(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
-    
-    var selectedDrawRound: ((Int) -> Void)?
+    private let cancelButton = StyledButton(title: "취소", buttonStyle: .assistive(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
+    private let confirmButton = StyledButton(title: "확인", buttonStyle: .solid(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        // 원하는 row (예: 3번째 row)를 선택 상태로 설정
+        // 원하는 row (예: 1133회차의 row)를 선택 상태로 설정
         if let currentRound = viewModel.currentLottoRound.value, let data = try? viewModel.lottoDrawRoundData.value() {
             if let selectedRow = rowForDraw(round: currentRound, from: data) {
                 pickerView.selectRow(selectedRow, inComponent: 0, animated: true)
@@ -38,10 +34,10 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        cancelButtonAction()
-        
         pickerView.delegate = self
         pickerView.dataSource = self
+        
+        cancelButtonAction()
         
         rootFlexContainer.backgroundColor = .white
         rootFlexContainer.layer.cornerRadius = 32
@@ -54,7 +50,7 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
         // 데이터가 업데이트될 때마다 pickerView를 리로드
         viewModel.lottoDrawRoundData
             .subscribe(onNext: { [weak self] _ in
-                self?.pickerView.reloadAllComponents() // 데이터 변경 시 UIPickerView 리로드
+                self?.pickerView.reloadAllComponents()
             })
             .disposed(by: disposeBag)
         
@@ -146,13 +142,13 @@ class DrawPickerViewController: UIViewController, UIPickerViewDelegate, UIPicker
             let roundText = "\(drawInfo.0)회"
             drawRoundLabel.text = roundText
             drawRoundLabel.font = Typography.font(.headline1)()
-//            drawRoundLabel.textColor = .black
+            drawRoundLabel.textColor = .black
             drawRoundLabel.textAlignment = NSTextAlignment.right
             
             let dateText = drawInfo.1.reformatDate
             drawDateLabel.text = dateText
             drawDateLabel.font = Typography.font(.body1)()
-//            drawDateLabel.textColor = .black
+            drawDateLabel.textColor = .black
             drawDateLabel.textAlignment = NSTextAlignment.left
             
             // 여러 기기에서 확인 필요

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawRoundBottomSheet.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawRoundBottomSheet.swift
@@ -1,0 +1,112 @@
+//
+//  DrawRoundBottomSheet.swift
+//  LottoMate
+//
+//  Created by Mirae on 9/6/24.
+//
+
+import UIKit
+import PinLayout
+import FlexLayout
+import RxSwift
+import RxGesture
+
+class DrawRoundBottomSheet: UIView {
+    let viewModel = LottoMateViewModel.shared
+    fileprivate let rootFlexContainer = UIView()
+    private let disposeBag = DisposeBag()
+    private var scrollView = UIScrollView()
+    
+    private let pickerTitleLabel = UILabel()
+    public let cancelButton = StyledButton(title: "취소", buttonStyle: .assistive(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
+    public let confirmButton = StyledButton(title: "확인", buttonStyle: .solid(.large, .active), fontSize: 16, cornerRadius: 8, verticalPadding: 12, horizontalPadding: 0)
+    
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .white
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        styleLabels()
+        drawRoundInfo()
+        addSubview(rootFlexContainer)
+        rootFlexContainer.flex.direction(.column).paddingTop(32).paddingBottom(28).define { flex in
+            flex.addItem(pickerTitleLabel).alignSelf(.start).paddingHorizontal(20).marginBottom(14)
+            flex.addItem(scrollView).direction(.column).height(120).minWidth(0).maxWidth(.infinity).define { flex in
+                for i in (1..<30).reversed() {
+                    let roundLabel = UILabel()
+                    let dateLabel = UILabel()
+                    
+                    roundLabel.text = "\(i)회"
+                    dateLabel.text = "2024.06.24"
+                    
+                    styleLabel(for: roundLabel, fontStyle: .headline1, textColor: .black)
+                    styleLabel(for: dateLabel, fontStyle: .body1, textColor: .black)
+                    
+                    roundLabel.rx.tapGesture()
+                        .when(.recognized)
+                        .subscribe(onNext: { [weak self] _ in
+                            guard let self = self else { return }
+                            print("\(roundLabel.text ?? "레이블")")
+                        })
+                        .disposed(by: disposeBag)
+                    
+                    flex.addItem().direction(.row).height(40).width(100%).justifyContent(.center).gap(20).define { flex in
+                        flex.addItem(roundLabel)
+                        flex.addItem(dateLabel)
+                    }.backgroundColor(i == 28 ? .red5 : .white)
+                }
+            }
+            
+            flex.addItem().direction(.row).justifyContent(.spaceBetween).gap(15).paddingHorizontal(20).marginTop(14).define { flex in
+                flex.addItem(cancelButton).grow(1)
+                flex.addItem(confirmButton).grow(1)
+            }
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        rootFlexContainer.pin.top(pin.safeArea.top).horizontally()
+        rootFlexContainer.flex.layout(mode: .adjustHeight)
+        
+        scrollView.contentSize = CGSize(width: rootFlexContainer.bounds.width, height: 600) // 예시로 높이를 설정
+    }
+    
+    private func styleLabels() {
+        pickerTitleLabel.text = "회차 선택"
+        styleLabel(for: pickerTitleLabel, fontStyle: .headline1, textColor: .black)
+    }
+    
+    private func drawRoundInfo() {
+        viewModel.latestLotteryResult
+            .subscribe(onNext: { result in
+                guard let latestLottoRound = result?.the645.drwNum,
+                      let drawRoundDate = result?.the645.drwDate else { return }
+                
+                // 30개 만들어보기
+                for round in (latestLottoRound-30...latestLottoRound).reversed() {
+                    let roundLabel = UILabel()
+                    let dateLabel = UILabel()
+                    
+                    roundLabel.text = "\(round)회"
+                    dateLabel.text = "\(drawRoundDate.reformatDate)"
+                    
+                    styleLabel(for: roundLabel, fontStyle: .headline1, textColor: .black)
+                    styleLabel(for: dateLabel, fontStyle: .body1, textColor: .black)
+                    
+                }
+            })
+            .disposed(by: disposeBag)
+        
+    }
+}
+
+#Preview {
+    let view = DrawRoundBottomSheet()
+    return view
+}

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawRoundBottomSheetViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/Subviews/DrawRoundBottomSheetViewController.swift
@@ -1,0 +1,29 @@
+//
+//  DrawRoundBottomSheetViewController.swift
+//  LottoMate
+//
+//  Created by Mirae on 9/6/24.
+//
+
+import UIKit
+
+class DrawRoundBottomSheetViewController: UIViewController {
+    fileprivate var mainView: DrawRoundBottomSheet {
+        return self.view as! DrawRoundBottomSheet
+    }
+    
+    let drawRoundBottomSheet = DrawRoundBottomSheet()
+    
+    override func loadView() {
+        view = drawRoundBottomSheet
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+#Preview {
+    let view = DrawRoundBottomSheetViewController()
+    return view
+}

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningInfoDetailView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningInfoDetailView.swift
@@ -13,7 +13,6 @@ import RxCocoa
 
 protocol WinningInfoDetailViewDelegate: AnyObject {
     func didTapBackButton()
-    func didTapDrawView()
 }
 
 class WinningInfoDetailView: UIView {
@@ -110,10 +109,6 @@ class WinningInfoDetailView: UIView {
         // Add the selected view to contentView
         contentView.addSubview(selectedView)
         self.layoutSubviews()
-    }
-    
-    @objc func didTapDrawView() {
-        delegate?.didTapDrawView()
     }
 }
 

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
@@ -49,7 +49,8 @@ class WinningNumbersDetailViewController: UIViewController {
         bind()
         bindViewModel()
         
-        viewModel.drawRoundPickerViewData()
+        viewModel.lottoDrawRoundPickerViewData()
+        viewModel.pensionLotteryDrawRoundPickerViewData()
         
         navTitleLabel.text = "당첨 정보 상세"
         styleLabel(for: navTitleLabel, fontStyle: .headline1, textColor: .primaryGray)
@@ -81,7 +82,7 @@ class WinningNumbersDetailViewController: UIViewController {
     }
     
     func bind() {
-        viewModel.lottoRoundTapEvent
+        viewModel.drawRoundTapEvent
             .subscribe(onNext: { isTapped in
                 guard let tapped = isTapped else { return }
                 if tapped {
@@ -133,7 +134,7 @@ extension WinningNumbersDetailViewController: WinningInfoDetailViewDelegate {
     func didTapBackButton() {
         navigationController?.popViewController(animated: true)
         // 뒤로간 후 다시 돌아올 때 회차 선택 피커뷰 나타남을 방지
-        self.viewModel.lottoRoundTapEvent.accept(false)
+        self.viewModel.drawRoundTapEvent.accept(false)
     }
 }
 

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
@@ -39,7 +39,6 @@ class WinningNumbersDetailViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
         // 뷰를 나타낼때마다 색이 적용되어 opacity가 변경됨... 점점 불투명해짐.
         changeStatusBarBgColor(bgColor: .commonNavBar)
     }
@@ -49,6 +48,8 @@ class WinningNumbersDetailViewController: UIViewController {
         
         bind()
         bindViewModel()
+        
+        viewModel.drawRoundPickerViewData()
         
         navTitleLabel.text = "당첨 정보 상세"
         styleLabel(for: navTitleLabel, fontStyle: .headline1, textColor: .primaryGray)
@@ -84,7 +85,7 @@ class WinningNumbersDetailViewController: UIViewController {
             .subscribe(onNext: { isTapped in
                 guard let tapped = isTapped else { return }
                 if tapped {
-                    self.showDrawPicker()
+                    self.showDrawRoundTest()
                 }
             })
             .disposed(by: disposeBag)
@@ -92,29 +93,6 @@ class WinningNumbersDetailViewController: UIViewController {
     
     @objc func backButtonTapped() {
         didTapBackButton()
-    }
-    
-    @objc func showDrawPicker() {
-        let pickerVC = DrawPickerViewController()
-        pickerVC.modalPresentationStyle = .pageSheet
-        pickerVC.modalTransitionStyle = .coverVertical
-        
-        pickerVC.selectedDrawInfo = { selectedInfo in
-            print("Selected draw info: \(selectedInfo)")
-        }
-//        present(pickerVC, animated: true, completion: nil)
-        
-        present(pickerVC, animated: true) {
-            if let sheet = pickerVC.sheetPresentationController {
-                sheet.detents = [
-                    .custom { context in
-                        print("pickerVC.view.frame.height: \(pickerVC.view.frame.height)")
-                        return 284.0
-                    }
-                ]
-                sheet.prefersGrabberVisible = false
-            }
-        }
     }
     
     func changeStatusBarBgColor(bgColor: UIColor?) {
@@ -132,14 +110,30 @@ class WinningNumbersDetailViewController: UIViewController {
                statusBarView?.backgroundColor = bgColor
            }
        }
+    
+    func showDrawRoundTest() {
+        let viewController = DrawPickerViewController()
+        
+        viewController.preferredContentSize = CGSize(width: UIScreen.main.bounds.width, height: (UIScreen.main.bounds.width / 1.25) - view.safeAreaInsets.bottom)
+        
+        presentBottomSheet(viewController: viewController, configuration: BottomSheetConfiguration(
+            cornerRadius: 32,
+            pullBarConfiguration: .hidden,
+            shadowConfiguration: .default
+        ), canBeDismissed: {
+            true
+        }, dismissCompletion: {
+            // handle bottom sheet dismissal completion
+            
+        })
+    }
 }
 
 extension WinningNumbersDetailViewController: WinningInfoDetailViewDelegate {
-    func didTapDrawView() {
-        showDrawPicker()
-    }
     func didTapBackButton() {
         navigationController?.popViewController(animated: true)
+        // 뒤로간 후 다시 돌아올 때 회차 선택 피커뷰 나타남을 방지
+        self.viewModel.lottoRoundTapEvent.accept(false)
     }
 }
 


### PR DESCRIPTION
# Description

- 당첨 정보 상세 화면(로또, 연금 복권)에서 사용자가 특정 회차를 선택할 수 있도록 회차 선택 Picker View를 구현하였습니다.
- Picker View를 통해 회차를 선택할 때, 해당 회차에 대한 당첨 정보를 불러올 수 있습니다.
- 주요 코드 리팩토링 및 불필요한 코드 정리도 함께 진행되었습니다.


# Changes

- 회차 선택 Picker View 추가
- 당첨 정보와 연동된 데이터 처리 로직 구현
- 불필요한 코드 제거 및 최적화