### PR TITLE
[ FEAT ] Add speeto page picker view (LTM-77)

### DIFF
--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/SpeetoWinningInfoDetail/SpeetoWinningInfoView.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/SpeetoWinningInfoDetail/SpeetoWinningInfoView.swift
@@ -108,6 +108,7 @@ class SpeetoWinningInfoView: UIView {
                 guard let self = self else { return }
                 self.viewModel.speetoPageTapEvent.accept(true)
             })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
+++ b/LottoMate/LottoMate/Views/TabViews/WinningInfoDetail/WinningNumbersDetailViewController.swift
@@ -49,8 +49,9 @@ class WinningNumbersDetailViewController: UIViewController {
         bind()
         bindViewModel()
         
-//        viewModel.lottoDrawRoundPickerViewData()
-//        viewModel.pensionLotteryDrawRoundPickerViewData()
+        // !NO_SERVER
+        viewModel.lottoDrawRoundPickerViewData()
+        viewModel.pensionLotteryDrawRoundPickerViewData()
         
         navTitleLabel.text = "당첨 정보 상세"
         styleLabel(for: navTitleLabel, fontStyle: .headline1, textColor: .primaryGray)
@@ -96,7 +97,7 @@ class WinningNumbersDetailViewController: UIViewController {
             .subscribe(onNext: { isTapped in
                 guard let tapped = isTapped else { return }
                 if tapped {
-//                    self.showCustomMenu()
+                    self.showDrawRoundTest()
                 }
             })
             .disposed(by: disposeBag)
@@ -124,8 +125,7 @@ class WinningNumbersDetailViewController: UIViewController {
     
     func showDrawRoundTest() {
         let viewController = DrawPickerViewController()
-        
-        viewController.preferredContentSize = CGSize(width: UIScreen.main.bounds.width, height: (UIScreen.main.bounds.width / 1.25) - view.safeAreaInsets.bottom)
+        viewController.preferredContentSize = CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width / 1.25)
         
         presentBottomSheet(viewController: viewController, configuration: BottomSheetConfiguration(
             cornerRadius: 32,


### PR DESCRIPTION
![Screenshot 2024-09-23 at 5 47 07 PM 1](https://github.com/user-attachments/assets/c1293b7d-c4c3-4d87-b7b0-2a09aa006806)



# Description
- 스피또 페이지 선택 바텀 시트 뷰를 추가하였습니다. 이 바텀 시트는 직관적인 UI를 제공하며, 사용자가 원하는 페이지로 빠르게 이동할 수 있습니다. 또한, 애니메이션 효과와 함께 사용자의 터치로 바텀 시트를 닫는 기능을 포함합니다.

# Changes 
- 스피또 페이지 선택 바텀 시트 뷰 구현: 사용자가 스피또 페이지를 쉽게 선택할 수 있도록 하단 시트 형태의 선택 UI를 추가했습니다.
- 페이지 번호 표시 기능: 각 스피또 페이지 번호가 목록 형태로 표시되며, 선택 시 해당 페이지로 이동합니다.
- 애니메이션 적용: 바텀 시트가 나타나고 사라질 때 자연스러운 애니메이션을 적용하였습니다.
- 닫기 기능: 바텀 시트 외부를 탭하거나 취소 버튼을 탭하면 시트가 닫히도록 설정하였습니다.    